### PR TITLE
Jeff matrices

### DIFF
--- a/LexiConHC/interface/LexiConHCCouplings.h
+++ b/LexiConHC/interface/LexiConHCCouplings.h
@@ -1,16 +1,20 @@
 #ifndef LEXICONHC_COUPLINGS_H
 #define LEXICONHC_COUPLINGS_H
 
-
+#include <math.h>
 #include <string>
 
 // Default values of parameters as in mod_Parameters.F90
 #define DEFVAL_MZ 91.1876
 #define DEFVAL_MW 80.399
 #define DEFVAL_SW 0.23119
+#define DEFVAL_CW sqrt (1- pow(DEFVAL_SW,2))
 #define DEFVAL_LAMBDA_VI 10000.
+#define DEFVAL_e .3028619
+#define DEFVAL_gs 1
 
 // Coupling definitions
+// Added gluon couplings that appear in H->VV
 #define AMPLITUDE_JHUGEN_COUPLING_COMMANDS \
   COUPLING_COMMAND(ghz1, ampjhu, 0.) \
   COUPLING_COMMAND(ghz1_prime2, ampjhu, 0.) \
@@ -25,6 +29,8 @@
   COUPLING_COMMAND(ghzgs4, ampjhu, 0.) \
   COUPLING_COMMAND(ghgsgs2, ampjhu, 0.) \
   COUPLING_COMMAND(ghgsgs4, ampjhu, 0.) \
+  COUPLING_COMMAND(ghg2, ampjhu, 0.) \
+  COUPLING_COMMAND(ghg4, ampjhu, 0.) \
   COUPLING_COMMAND(dV_Z, ampjhu, 0.) \
   COUPLING_COMMAND(dV_A, ampjhu, 0.) \
   COUPLING_COMMAND(dP_Z, ampjhu, 0.) \
@@ -35,7 +41,7 @@
   COUPLING_COMMAND(dFour_A, ampjhu, 0.) \
   COUPLING_COMMAND(dZZWpWm, ampjhu, 0.) \
   COUPLING_COMMAND(dZAWpWm, ampjhu, 0.) \
-  COUPLING_COMMAND(dAAWpWm, ampjhu, 0.)
+  COUPLING_COMMAND(dAAWpWm, ampjhu, 0.) \
 
 #define EFT_JHUGEN_COUPLING_COMMANDS \
   COUPLING_COMMAND(ghz1, eftjhu, 0.) \
@@ -45,23 +51,39 @@
   COUPLING_COMMAND(ghzgs2, eftjhu, 0.) \
   COUPLING_COMMAND(ghzgs4, eftjhu, 0.) \
   COUPLING_COMMAND(ghgsgs2, eftjhu, 0.) \
-  COUPLING_COMMAND(ghgsgs4, eftjhu, 0.)
+  COUPLING_COMMAND(ghgsgs4, eftjhu, 0.) \
+  COUPLING_COMMAND(ghg2, eftjhu, 0.) \
+  COUPLING_COMMAND(ghg4, eftjhu, 0.) \
+
+// Renamed the EFT_Higgs basis couplings to match rosetta naming convention
+#define HIGGSBASIS_COUPLING_COMMANDS \
+  COUPLING_COMMAND(dCz, hbasis, 0.) \
+  COUPLING_COMMAND(Czz, hbasis, 0.) \
+  COUPLING_COMMAND(Czbx, hbasis, 0.) \
+  COUPLING_COMMAND(tCzz, hbasis, 0.) \
+  COUPLING_COMMAND(dCw, hbasis, 0.) \
+  COUPLING_COMMAND(Cww, hbasis, 0.) \
+  COUPLING_COMMAND(Cwbx, hbasis, 0.) \
+  COUPLING_COMMAND(tCww, hbasis, 0.) \
+  COUPLING_COMMAND(Cza, hbasis, 0.) \
+  COUPLING_COMMAND(tCza, hbasis, 0.) \
+  COUPLING_COMMAND(Cabx, hbasis, 0.) \
+  COUPLING_COMMAND(Caa, hbasis, 0.) \
+  COUPLING_COMMAND(tCaa, hbasis, 0.) \
+  COUPLING_COMMAND(Cgg, hbasis, 0.) \
+  COUPLING_COMMAND(tCgg, hbasis, 0.)
 
 #define EFT_HIGGSBASIS_COUPLING_COMMANDS \
-  COUPLING_COMMAND(d_cz, efthbasis, 0.) \
-  COUPLING_COMMAND(czz, efthbasis, 0.) \
-  COUPLING_COMMAND(cz_box, efthbasis, 0.) \
-  COUPLING_COMMAND(czz_tilde, efthbasis, 0.) \
-  COUPLING_COMMAND(d_cw, efthbasis, 0.) \
-  COUPLING_COMMAND(cww, efthbasis, 0.) \
-  COUPLING_COMMAND(cw_box, efthbasis, 0.) \
-  COUPLING_COMMAND(cww_tilde, efthbasis, 0.) \
-  COUPLING_COMMAND(czgs, efthbasis, 0.) \
-  COUPLING_COMMAND(czgs_tilde, efthbasis, 0.) \
-  COUPLING_COMMAND(cgs_box, efthbasis, 0.) \
-  COUPLING_COMMAND(cgsgs, efthbasis, 0.) \
-  COUPLING_COMMAND(cgsgs_tilde, efthbasis, 0.)
-
+  COUPLING_COMMAND(dCz, efthbasis, 0.) \
+  COUPLING_COMMAND(Czbx, efthbasis, 0.) \
+  COUPLING_COMMAND(Czz, efthbasis, 0.) \
+  COUPLING_COMMAND(tCzz, efthbasis, 0.) \
+  COUPLING_COMMAND(Cza, efthbasis, 0.) \
+  COUPLING_COMMAND(tCza, efthbasis, 0.) \
+  COUPLING_COMMAND(Caa, efthbasis, 0.) \
+  COUPLING_COMMAND(tCaa, efthbasis, 0.) \
+  COUPLING_COMMAND(Cgg, efthbasis, 0.) \
+  COUPLING_COMMAND(tCgg, efthbasis, 0.)
 
 namespace LexiConHCCouplings{
 #define COUPLING_COMMAND(NAME, PREFIX, DEFVAL) coupl_##PREFIX##_##NAME,
@@ -74,18 +96,23 @@ namespace LexiConHCCouplings{
     EFT_JHUGEN_COUPLING_COMMANDS
     nEFT_JHUGen_CouplingTypes
   };
+  enum HiggsBasis_CouplingType{
+    HIGGSBASIS_COUPLING_COMMANDS
+    nHiggsBasis_CouplingTypes
+  };
   enum EFT_HiggsBasis_CouplingType{
     EFT_HIGGSBASIS_COUPLING_COMMANDS
     nEFT_HiggsBasis_CouplingTypes
   };
+  
 
 #undef COUPLING_COMMAND
 
   // Functions to get the coupling names from the indices
   std::string getCouplingName(LexiConHCCouplings::Amplitude_JHUGen_CouplingType type);
   std::string getCouplingName(LexiConHCCouplings::EFT_JHUGen_CouplingType type);
+  std::string getCouplingName(LexiConHCCouplings::HiggsBasis_CouplingType type); 
   std::string getCouplingName(LexiConHCCouplings::EFT_HiggsBasis_CouplingType type);
-
 }
 
 

--- a/LexiConHC/interface/LexiConHCIOHelpers.h
+++ b/LexiConHC/interface/LexiConHCIOHelpers.h
@@ -9,7 +9,7 @@ namespace LexiConHCIOHelpers{
 
     bEFT_JHUGen,
     bEFT_HiggsBasis,
-
+    bHiggsBasis,
     nIOBases
   };
 

--- a/LexiConHC/src/LexiConHCCouplings.cc
+++ b/LexiConHC/src/LexiConHCCouplings.cc
@@ -27,6 +27,14 @@ std::string LexiConHCCouplings::getCouplingName(LexiConHCCouplings::EFT_JHUGen_C
     assert(0);
   }
 }
+std::string LexiConHCCouplings::getCouplingName(LexiConHCCouplings::HiggsBasis_CouplingType type){
+  switch (type){
+    HIGGSBASIS_COUPLING_COMMANDS
+  default:
+    cerr << "LexiConHCCouplings::getCouplingName: Type " << type << " is undefined." << endl;
+    assert(0);
+  }
+}
 std::string LexiConHCCouplings::getCouplingName(LexiConHCCouplings::EFT_HiggsBasis_CouplingType type){
   switch (type){
     EFT_HIGGSBASIS_COUPLING_COMMANDS

--- a/LexiConHC/src/LexiConHCIOHelpers.cc
+++ b/LexiConHC/src/LexiConHCIOHelpers.cc
@@ -23,6 +23,9 @@ namespace LexiConHCIOHelpers{
       case bEFT_JHUGen:
         strtype = "eft_jhu";
         break;
+      case bHiggsBasis:
+        strtype = "hbasis";
+	break;
       case bEFT_HiggsBasis:
         strtype = "eft_hbasis";
         break;

--- a/LexiConHC/src/LexiConHCOptionParser.cc
+++ b/LexiConHC/src/LexiConHCOptionParser.cc
@@ -106,6 +106,8 @@ void LexiConHCOptionParser::printOptionsHelp(bool command_fail)const{
   AMPLITUDE_JHUGEN_COUPLING_COMMANDS;
   cout << "- Allowed couplings for the JHUGen EFT formalism:\n";
   EFT_JHUGEN_COUPLING_COMMANDS;
+  cout << "- Allowed couplings for the Higgs basis formalism without EFT constraints:\n";
+  HIGGSBASIS_COUPLING_COMMANDS;
   cout << "- Allowed couplings for the Higgs basis EFT formalism:\n";
   EFT_HIGGSBASIS_COUPLING_COMMANDS;
 #undef COUPLING_COMMAND

--- a/LexiConHC/src/LexiConHCTranslator.cc
+++ b/LexiConHC/src/LexiConHCTranslator.cc
@@ -32,16 +32,51 @@ void LexiConHCTranslator::translate(){
   std::vector< std::pair<double, double> > vinput = getOrderedInputCouplings(basis_input, input_flags, input_parameters, input_couplings);
   // Assign the output vector
   std::vector< std::pair<double, double> > voutput(tmatrix.size(), std::pair<double, double>(0, 0));
-
+  for (int i = 0; i < tmatrix.size(); i++)
+      {
+        for (int j = 0; j < tmatrix[i].size(); j++)
+        {
+            cout << tmatrix[i][j] << ",";
+        }
+        cout << "\n";
+      }
+  for (int i = 0; i < vinput.size(); i++)
+  {
+	cout << "(" << vinput[i].first << "," << vinput[i].second << ")";
+  }
+  cout <<"\n";
+  for (int i = 0; i < voutput.size(); i++)
+  {
+        cout << "(" << voutput[i].first << "," << voutput[i].second << ")";
+  }
   // Do the matrix multiplication
   for (size_t i=0; i<tmatrix.size(); i++){
     auto const& trow = tmatrix.at(i);
     for (size_t j=0; j<trow.size(); j++){
-      voutput.at(j).first += trow.at(j) * vinput.at(j).first;
-      voutput.at(j).second += trow.at(j) * vinput.at(j).second;
+      voutput.at(i).first += trow.at(j) * vinput.at(j).first;
+      voutput.at(i).second += trow.at(j) * vinput.at(j).second;
     }
   }
-
+  // Fix output by subracting by constant vector 
+  if (basis_input == bAmplitude_JHUGen && basis_output == bEFT_HiggsBasis){
+     voutput.at(0).first -= 1;
+     voutput.at(4).first -= 1;
+  }
+  else if (basis_input == bEFT_JHUGen && basis_output == bHiggsBasis){
+     voutput.at(0).first -= 1;
+     voutput.at(4).first -= 1;
+  }
+  else if (basis_input == bEFT_JHUGen && basis_output == bEFT_HiggsBasis){
+     voutput.at(0).first -= 1;
+  }
+  else if (basis_input == bHiggsBasis && basis_output == bAmplitude_JHUGen){
+     voutput.at(0).first += 2;
+     voutput.at(4).first += 2;
+  }
+  else if (basis_input == bEFT_HiggsBasis && basis_output == bAmplitude_JHUGen){
+     voutput.at(0).first += 2;
+     voutput.at(4).first += 2;
+  }
   // Set the results
   interpretOutputCouplings(basis_output, input_flags, input_parameters, voutput);
 }
@@ -50,77 +85,251 @@ std::vector<std::vector<double>> LexiConHCTranslator::getTranslationMatrix(
   LexiConHCIOHelpers::IOBasisType const& basis_input, LexiConHCIOHelpers::IOBasisType const& basis_output,
   std::unordered_map<std::string, double> const& input_parameters
 ) const{
+  double e; getValueWithDefault<std::string, double>(input_parameters, "e", e, DEFVAL_e);
+  double gs; getValueWithDefault<std::string, double>(input_parameters, "gs", gs, DEFVAL_gs);
   double sw; getValueWithDefault<std::string, double>(input_parameters, "sin2ThetaW", sw, DEFVAL_SW);
+  double cw; getValueWithDefault<std::string, double>(input_parameters, "cos2ThetaW", cw, DEFVAL_CW);
+  double MZ; getValueWithDefault<std::string, double>(input_parameters, "MZ", MZ, DEFVAL_MZ);
+  double MW; getValueWithDefault<std::string, double>(input_parameters, "MW", MW, DEFVAL_MW);
+  double Lambda_z1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_z1", Lambda_z1, DEFVAL_LAMBDA_VI);
+  double Lambda_w1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_w1", Lambda_w1, DEFVAL_LAMBDA_VI);
+  double Lambda_zgs1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_zgs1", Lambda_zgs1, DEFVAL_LAMBDA_VI);
   std::vector<std::vector<double>> res;
 
   // This is where the translation matrixes should be coded carefully.
   // See also the getOrderedInputCouplings and interpretOutputCouplings functions for what the input/output vectors expect for JHUGen conventions (e.g. ghz1_prime2 scaled already by MZ^2/L1ZZ^2, so no need to put that for example).
   if (basis_input == bAmplitude_JHUGen){
     if (basis_output == bAmplitude_JHUGen){
-      res.assign(nAmplitude_JHUGen_CouplingTypes, std::vector<double>(nAmplitude_JHUGen_CouplingTypes, 0));
+      res.assign(nAmplitude_JHUGen_CouplingTypes, std::vector<double>(nAmplitude_JHUGen_CouplingTypes, 0));//Assign Correct Dimensions of translation matrix
       for (size_t i=0; i<(size_t) nAmplitude_JHUGen_CouplingTypes; i++) res.at(i).at(i)=1;
     }
     else if (basis_output == bEFT_JHUGen){
       res.assign(nEFT_JHUGen_CouplingTypes, std::vector<double>(nAmplitude_JHUGen_CouplingTypes, 0));
-      /*
-      res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+      
+    }
+    else if (basis_output == bHiggsBasis){
+      res.assign(nEFT_HiggsBasis_CouplingTypes, std::vector<double>(nAmplitude_JHUGen_CouplingTypes, 0));
+      res = std::vector<std::vector<double>> { 
+	{0.5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,(-2*pow(cw,2)*pow(sw,2))/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,(pow(MZ,2)*pow(sw,2))/(pow(e,2)*pow(Lambda_z1,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,0,0,(-2*pow(cw,2)*pow(sw,2))/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,0,0,0.5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,0,0,0,0,0,(-2*pow(sw,2))/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,0,0,0,(-2*pow(cw,2)*pow(sw,2))/(pow(e,2)*pow(Lambda_w1,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,0,0,0,0,0,0,(-2*pow(sw,2))/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,0,0,0,0,0,0,0,(-2*(sw) * cw /pow(e,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,0,0,0,0,0,0,0,0,0,(-2*(sw) * cw /pow(e,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,0,0,0,0,0,0,(cw*pow(MZ,2)*sw)/(pow(e,2)*pow(Lambda_zgs1,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+   	{0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0,0},
+	{0,0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(e,2),0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(gs,2),0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(gs,2),0,0,0,0,0,0,0,0,0,0} };
+      
     }
     else if (basis_output == bEFT_HiggsBasis){
       res.assign(nEFT_HiggsBasis_CouplingTypes, std::vector<double>(nAmplitude_JHUGen_CouplingTypes, 0));
-      /*
-      res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+    /*  res = std::vector<std::vector<double>> {
+        {0.5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,(-2*pow(DEFVAL_CW,2)*pow(DEFVAL_SW,2))/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,(pow(DEFVAL_MZ,2)*pow(DEFVAL_SW,2))/(pow(DEFVAL_e,2)*pow(DEFVAL_LAMBDA_VI,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,(-2*pow(DEFVAL_CW,2)*pow(DEFVAL_SW,2))/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0.5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,(-2*pow(DEFVAL_SW,2))/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,(-2*pow(DEFVAL_CW,2)*pow(DEFVAL_SW,2))/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,(-2*pow(DEFVAL_SW,2))/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,(-2*(DEFVAL_SW) * DEFVAL_CW /pow(DEFVAL_e,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,0,(-2*(DEFVAL_SW) * DEFVAL_CW /pow(DEFVAL_e,2)),0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,(DEFVAL_CW*pow(DEFVAL_MZ,2)*DEFVAL_SW)/(pow(DEFVAL_e,2)*pow(DEFVAL_LAMBDA_VI,2)),0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0,0},
+        {0,0,0,0,0,0,0,0,0,0,0,0,0,-2/pow(DEFVAL_e,2),0,0,0,0,0,0,0,0,0,0} }; */
     }
   }
   else if (basis_input == bEFT_JHUGen){
     if (basis_output == bAmplitude_JHUGen){
       res.assign(nAmplitude_JHUGen_CouplingTypes, std::vector<double>(nEFT_JHUGen_CouplingTypes, 0));
-      /*
-      res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+      res = std::vector<std::vector<double>> {
+					     {1, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 1, 0, 0, 0, 0, 0, 0},
+                                             {1, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0,1/pow(Lambda_z1,2) * pow(Lambda_w1,2)/(pow(cw,2) - pow(sw,2)),(-2*pow(sw,2))/pow(MZ,2) * pow(Lambda_w1,2)/(pow(cw,2) - pow(sw,2)),0,(2*sw)/cw *(pow(cw,2) - pow(sw,2))/pow(MZ,2)*pow(Lambda_w1,2)/(pow(cw,2) - pow(sw,2)),0,(2*pow(sw,2))/pow(MZ,2)*pow(Lambda_w1,2)/(pow(cw,2) - pow(sw,2)),0, 0, 0},
+                                             {0, 0, pow(cw,2), 0, 2*sw*cw, 0, pow(sw,2), 0, 0, 0},
+                                             {0, 0, 0, pow(cw,2), 0, 2*sw*cw, 0, pow(sw,2), 0, 0},
+                                             {0, (2*sw*cw)/pow(Lambda_z1,2)*pow(Lambda_zgs1,2)/(pow(cw,2) - pow(sw,2)),(-2*sw*cw)/pow(MZ,2),pow(Lambda_zgs1,2)/(pow(cw,2) - pow(sw,2)),0,(2*(pow(cw,2) - pow(sw,2)))/pow(MZ,2) * pow(Lambda_zgs1,2)/(pow(cw,2) - pow(sw,2)),0,(2*sw*cw)/pow(MZ,2)*pow(Lambda_zgs1,2)/(pow(cw,2) - pow(sw,2)), 0, 0, 0},
+                                             {0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 1, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 1, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 1, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		   			     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+   					     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                                             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
     }
     else if (basis_output == bEFT_JHUGen){
       res.assign(nEFT_JHUGen_CouplingTypes, std::vector<double>(nEFT_JHUGen_CouplingTypes, 0));
       for (size_t i=0; i<(size_t) nEFT_JHUGen_CouplingTypes; i++) res.at(i).at(i)=1;
     }
-    else if (basis_output == bEFT_HiggsBasis){
-      res.assign(nEFT_HiggsBasis_CouplingTypes, std::vector<double>(nEFT_JHUGen_CouplingTypes, 0));
-      /*
+    else if (basis_output == bHiggsBasis){
+      res.assign(nHiggsBasis_CouplingTypes, std::vector<double>(nEFT_JHUGen_CouplingTypes, 0)); 
       res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+				      {1/2, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				      {0, 0, -((2*pow(cw,2)*pow(sw,2))/pow(e,2)), 0, 0, 0, 0, 0, 0 ,0},
+				      {0, (pow(MZ,2)*pow(sw,2))/(pow(e,2)*pow(Lambda_z1,2)), 0, 0, 0, 0, 0, 0, 0, 0},
+				      {0, 0, 0, -((2*pow(cw,2)*pow(sw,2))/pow(e,2)), 0, 0, 0, 0, 0, 0},
+				      {1/2, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				      {0, 0, -(2*(pow(cw,2)*pow(sw,2))/pow(e,2)), 0, -((4*cw*pow(sw,3))/pow(e,2)), 0, -((2*pow(sw,4))/pow(e,2)), 0, 0, 0},
+				      {0, (pow(MW,2)*pow(sw,2))/(pow(e,2)*Lambda_z1*(pow(cw,2) - pow(sw,2))), -((2*pow(MW,2)*pow(sw,4))/(pow(e,2)*pow(MZ,2)*(pow(cw,2) - pow(sw,2)))),0,(2*pow(MW,2)*pow(sw,3))/(cw*pow(e,2)*pow(MZ,2)), 0,(2*pow(MW,2)*pow(sw,4))/(pow(e,2)*pow(MZ,2)*(pow(cw,2) - pow(sw,2))), 0, 0, 0},
+				      {0, 0, 0, -((2*pow(cw,2)*pow(sw,2))/pow(e,2)), 0,-((4*cw*pow(sw,3))/pow(e,2)), 0, -((2*pow(sw,4))/pow(e,2)), 0, 0},
+				      {0, 0, 0, 0, -((2*cw*sw)/pow(e,2)), 0, 0, 0, 0, 0},
+				      {0, 0, 0, 0, 0, -((2*cw*sw)/pow(e,2)), 0, 0, 0, 0},
+				      {0, (2*pow(cw,2)*pow(MZ,2)*pow(sw,2))/(pow(e,2)*pow(Lambda_z1,2)*(pow(cw,2) - pow(sw,2))), -((2*pow(cw,2)*pow(sw,2))/(pow(e,2)*(pow(cw,2) - pow(sw,2)))),0,(2*cw*sw)/pow(e,2), 0, (2*pow(cw,2)*pow(sw,2))/(pow(e,2)*(pow(cw,2) - pow(sw,2))), 0, 0, 0},
+				      {0, 0, 0, 0, 0, 0, -(2/pow(e,2)), 0, 0, 0},
+				      {0, 0, 0, 0, 0, 0, 0, -(2/pow(e,2)), 0, 0},
+				      {0, 0, 0, 0, 0, 0, 0, 0, -2/pow(gs,2), 0},
+				      {0, 0, 0, 0, 0, 0, 0, 0, 0, -2/pow(gs,2)}};
+      }
+    else if (basis_output == bEFT_HiggsBasis){
+      res.assign(nHiggsBasis_CouplingTypes, std::vector<double>(nEFT_JHUGen_CouplingTypes, 0));
+      res = std::vector<std::vector<double>>{
+				    	    {1/2, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					    {0, (pow(MZ,2)* pow(sw,2))/(pow(e,2)*pow(Lambda_z1,2)), 0, 0, 0, 0, 0, 0, 0, 0},
+					    {0, 0, (-2*pow(sw,2)*pow(cw,2))/pow(e,2), 0, 0, 0, 0, 0, 0, 0},
+					    {0, 0, 0, (-2*pow(sw,2)*pow(cw,2))/pow(e,2), 0, 0, 0, 0, 0, 0},
+					    {0, 0, 0, 0, (-2*sw*cw)/pow(e,2), 0, 0, 0 , 0, 0},
+					    {0, 0, 0, 0, 0, (-2*sw*cw)/pow(e,2), 0, 0, 0, 0},
+					    {0, 0, 0, 0, 0, 0, (-2)/pow(e,2), 0, 0, 0},
+					    {0, 0, 0, 0, 0, 0, 0, -2/pow(e,2), 0, 0},
+					    {0, 0, 0, 0, 0, 0, 0, 0, -2/pow(gs,2), 0},
+					    {0, 0, 0, 0, 0, 0, 0, 0, 0, -2/pow(gs,2)}};
+  }
+}
+  else if (basis_input == bHiggsBasis){
+    cout << "HERE" ;
+    if (basis_output == bAmplitude_JHUGen){
+      res.assign(nAmplitude_JHUGen_CouplingTypes, std::vector<double>(nHiggsBasis_CouplingTypes, 0));
+        res = std::vector<std::vector<double>>{
+				{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, (pow(e,2)*pow(Lambda_z1,2))/(pow(MZ,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, -(pow(e,2)/(2*pow(cw,2) * pow(sw,2))), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, -(pow(e,2)/(2*pow(cw,2)*pow(sw,2))), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, (pow(e,2)*pow(Lambda_w1,2))/(pow(MW,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, -(pow(e,2)/(2*pow(sw,2))), 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/(2*pow(sw,2))), 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (pow(e,2)*pow(Lambda_zgs1,2))/(cw*pow(MZ,2)*sw), 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2), 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2)},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+  				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+ 
+    }
+    else if (basis_output == bEFT_JHUGen){
+      res.assign(nEFT_JHUGen_CouplingTypes, std::vector<double>(nHiggsBasis_CouplingTypes, 0));
+      /*
+ *       res = std::vector<std::vector<double>>{
+ *               {  },
+ *                       {  }
+ *                             };
+ *                                */
+    }
+    else if (basis_output == bEFT_HiggsBasis){
+      res.assign(nEFT_HiggsBasis_CouplingTypes, std::vector<double>(nHiggsBasis_CouplingTypes, 0));
+      
+    }
+    else if (basis_output == bHiggsBasis){
+      res.assign(nHiggsBasis_CouplingTypes, std::vector<double>(nHiggsBasis_CouplingTypes, 0));
+      for (size_t i=0; i<(size_t) nHiggsBasis_CouplingTypes; i++) res.at(i).at(i)=1;
     }
   }
   else if (basis_input == bEFT_HiggsBasis){
     if (basis_output == bAmplitude_JHUGen){
       res.assign(nAmplitude_JHUGen_CouplingTypes, std::vector<double>(nEFT_HiggsBasis_CouplingTypes, 0));
-      /*
       res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+					{2, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, (pow(e,2)*pow(Lambda_z1,2))/(pow(MZ,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, -(pow(e,2)/(2*pow(cw,2)*pow(sw,2))), 0, 0, 0, 0, 0, 0, 0},
+					{0, 0, 0, -(pow(e,2))/(2*pow(cw,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0}, 
+					{2, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, (pow(e,2)*pow(Lambda_w1,2))/(pow(MZ,2)*pow(sw,2)*(pow(cw,2) - pow(sw,2))),(pow(e,2)*pow(Lambda_w1,2))/(pow(cw,2)*pow(MZ,2)*(pow(cw,2) - pow(sw,2))), 0, -((pow(e,2)*pow(Lambda_w1,2))/(pow(cw,2)*pow(MZ,2))), 0, -((pow(e,2)*pow(Lambda_w1,2)*pow(sw,2))/(pow(MZ,2)*(pow(cw,2) - pow(sw,2)))), 0, 0, 0}, 
+					{0, 0, -(pow(e,2)/(2*pow(sw,2))), 0, -pow(e,2), 0, -(1/2)*pow(e,2)*pow(sw,2), 0, 0, 0}, 
+					{0, 0, 0, -(pow(e,2))/(2*pow(sw,2)), 0, -pow(e,2), 0, -(1/2)*pow(e,2)*pow(sw,2), 0, 0}, 
+					{0, (2*cw*pow(e,2)*pow(Lambda_zgs1,2))/(pow(MZ,2)*sw*(pow(cw,2) - pow(sw,2))),(pow(e,2)*pow(Lambda_zgs1,2))/(cw*pow(MZ,2)*sw*(pow(cw,2) - pow(sw,2))), 0, -((pow(e,2)*pow(Lambda_zgs1,2))/(cw*pow(MZ,2)*sw)), 0, -((cw*pow(e,2)* pow(Lambda_zgs1,2)*sw)/(pow(MZ,2)*(pow(cw,2) - pow(sw,2)))), 0, 0, 0},
+					{0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0, 0},
+					{0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2), 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2)}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
     }
     else if (basis_output == bEFT_JHUGen){
       res.assign(nEFT_JHUGen_CouplingTypes, std::vector<double>(nEFT_HiggsBasis_CouplingTypes, 0));
-      /*
       res = std::vector<std::vector<double>>{
-        {  },
-        {  }
-      };
-      */
+				{2, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+				{0, (pow(e,2)*pow(Lambda_z1,2))/(pow(MZ,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0, 0, 0}, 
+				{0, 0, -(pow(e,2))/(2*pow(cw,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0, 0}, 
+				{0, 0, 0, -pow(e,2)/(2*pow(cw,2)*pow(sw,2)), 0, 0, 0, 0, 0, 0}, 
+				{0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0, 0}, 
+				{0, 0, 0, 0, 0, -(pow(e,2)/(2*cw*sw)), 0, 0, 0, 0}, 
+				{0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0, 0}, 
+				{0, 0, 0, 0, 0, 0, 0, -(pow(e,2)/2), 0, 0}, 
+				{0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2), 0}, 
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, -(pow(gs,2)/2)}};
+    }
+    else if (basis_output == bHiggsBasis){
+      res.assign(nHiggsBasis_CouplingTypes, std::vector<double>(nEFT_HiggsBasis_CouplingTypes, 0));
+      
+         res = std::vector<std::vector<double>>{
+					{1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 1, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 1, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 1, 0, 0, 0, 0, 0, 0}, 
+					{1, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 
+					{0, 0, 1, 0, 2*pow(sw,2), 0,pow(sw,4), 0, 0, 0}, 
+					{0, pow(MW,2)/(pow(MZ,2)*(pow(cw,2) - pow(sw,2))),(pow(MW,2)*pow(sw,2))/(pow(cw,2)*pow(MZ,2)*(pow(cw,2) - pow(sw,2))), 0, -((pow(MW,2)*pow(sw,2))/(pow(cw,2)*pow(MZ,2))), 0, -((pow(MW,2)*pow(sw,4))/(pow(MZ,2)*(pow(cw,2) - pow(sw,2)))), 0, 0, 0}, 
+					{0, 0, 0, 1, 0, 2*pow(sw,2),0, pow(sw,4), 0, 0}, 
+					{0, 0, 0, 0, 1, 0, 0, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 1, 0, 0, 0, 0}, 
+					{0, (2*pow(cw,2))/(pow(cw,2) - pow(sw,2)), 1/(pow(cw,2) - pow(sw,2)), 0, -1, 0, -((pow(cw,2)*pow(sw,2))/(pow(cw,2) - pow(sw,2))), 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 1, 0, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 1, 0, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 1, 0}, 
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
+ 
     }
     else if (basis_output == bEFT_HiggsBasis){
       res.assign(nEFT_HiggsBasis_CouplingTypes, std::vector<double>(nEFT_HiggsBasis_CouplingTypes, 0));
@@ -171,6 +380,12 @@ std::vector< std::pair<double, double> > LexiConHCTranslator::getOrderedInputCou
     EFT_JHUGEN_COUPLING_COMMANDS;
     break;
   }
+  case bHiggsBasis:
+  {
+    res.assign(nHiggsBasis_CouplingTypes, std::pair<double, double>(0, 0));
+    HIGGSBASIS_COUPLING_COMMANDS;
+    break;
+  }
   case bEFT_HiggsBasis:
   {
     res.assign(nEFT_HiggsBasis_CouplingTypes, std::pair<double, double>(0, 0));
@@ -200,14 +415,12 @@ void LexiConHCTranslator::interpretOutputCouplings(
   double Lambda_z1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_z1", Lambda_z1, DEFVAL_LAMBDA_VI);
   double Lambda_w1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_w1", Lambda_w1, DEFVAL_LAMBDA_VI);
   double Lambda_zgs1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_zgs1", Lambda_zgs1, DEFVAL_LAMBDA_VI);
-
 #define COUPLING_COMMAND(NAME, PREFIX, DEFVAL) \
   if (useMCFMAtOutput && (std::string(#NAME).find("ghz")!=std::string::npos || std::string(#NAME).find("ghw")!=std::string::npos)){ output_vector.at(coupl_##PREFIX##_##NAME).first /= 2.; output_vector.at(coupl_##PREFIX##_##NAME).second /= 2.; } \
   if (std::string(#NAME).find("ghzgs")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_zgs1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_zgs1, 2); } \
   else if (std::string(#NAME).find("ghz")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_z1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_z1, 2); } \
   else if (std::string(#NAME).find("ghw")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MW/Lambda_w1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MW/Lambda_w1, 2); } \
   result_couplings[#NAME] = output_vector.at(coupl_##PREFIX##_##NAME);
-
   switch (basis_output){
   case bAmplitude_JHUGen:
   {
@@ -217,6 +430,11 @@ void LexiConHCTranslator::interpretOutputCouplings(
   case bEFT_JHUGen:
   {
     EFT_JHUGEN_COUPLING_COMMANDS;
+    break;
+  }
+  case bHiggsBasis:
+  {
+    HIGGSBASIS_COUPLING_COMMANDS;
     break;
   }
   case bEFT_HiggsBasis:


### PR DESCRIPTION
Added a new set of couplings for Higgs without EFT constraints and coded all rotation matrices for all basis. Basis with 0 matrix for rotations are impractical to code. For example Amplitude JHUGen to EFTJhuGen doesn't make sense because we would have to check input for EFT relations anyway. I also added some more free parameters such as gs and e.